### PR TITLE
fix wrong namespace + up with var to verify ssl in client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kapersoft\ShareFile;
+namespace Kapersoft\Sharefile;
 
 use Exception;
 use GuzzleHttp\Psr7;
@@ -62,12 +62,13 @@ class Client
      * @param string                   $username      ShareFile username
      * @param string                   $password      ShareFile password
      * @param MockHandler|HandlerStack $handler       Guzzle Handler
+     * @param boolean                  $verify_ssl    Describes the SSL certificate verification behavior of a request
      *
      * @throws Exception
      */
-    public function __construct(string $hostname, string $client_id, string $client_secret, string $username, string $password, $handler = null)
+    public function __construct(string $hostname, string $client_id, string $client_secret, string $username, string $password, $handler = null, $verify_ssl = true)
     {
-        $response = $this->authenticate($hostname, $client_id, $client_secret, $username, $password, $handler);
+        $response = $this->authenticate($hostname, $client_id, $client_secret, $username, $password, $handler, $verify_ssl);
 
         if (! isset($response['access_token']) || ! isset($response['subdomain'])) {
             throw new Exception("Incorrect response from Authentication: 'access_token' or 'subdomain' is missing.");
@@ -77,6 +78,7 @@ class Client
         $this->client = new GuzzleClient(
             [
                 'handler' => $handler,
+                'verify' => $verify_ssl,
                 'headers' => [
                     'Authorization' => "Bearer {$this->token['access_token']}",
                 ],
@@ -93,12 +95,13 @@ class Client
      * @param string                   $username      ShareFile username
      * @param string                   $password      ShareFile password
      * @param MockHandler|HandlerStack $handler       Guzzle Handler
+     * @param boolean                  $verify_ssl    Describes the SSL certificate verification behavior of a request
      *
      * @throws Exception
      *
      * @return array
      */
-    protected function authenticate(string $hostname, string $client_id, string $client_secret, string $username, string $password, $handler = null):array
+    protected function authenticate(string $hostname, string $client_id, string $client_secret, string $username, string $password, $handler = null, $verify_ssl = true):array
     {
         $uri = "https://{$hostname}/oauth/token";
 
@@ -111,7 +114,7 @@ class Client
         ];
 
         try {
-            $client = new GuzzleClient(['handler' => $handler]);
+            $client = new GuzzleClient(['handler' => $handler, 'verify' => $verify_ssl]);
             $response = $client->post(
                 $uri,
                 ['form_params' => $parameters]


### PR DESCRIPTION
namespace should be the same than the other.
In some case, it can be necessary to disable the verify SSL, I added the choice with true by default